### PR TITLE
Port library for ESP-IDF usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB_RECURSE GXEPD2_SOURCES "src/*.cpp" "idf/*.cpp")
+
+idf_component_register(
+    SRCS ${GXEPD2_SOURCES}
+    INCLUDE_DIRS "src" "idf"
+    REQUIRES driver freertos
+)

--- a/idf/Arduino.h
+++ b/idf/Arduino.h
@@ -1,0 +1,72 @@
+#ifndef ARDUINO_COMPAT_H
+#define ARDUINO_COMPAT_H
+
+#include <stdint.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+#include "esp_rom_sys.h"
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Basic constants
+#define HIGH 1
+#define LOW  0
+
+#define INPUT GPIO_MODE_INPUT
+#define OUTPUT GPIO_MODE_OUTPUT
+#define INPUT_PULLUP GPIO_MODE_INPUT
+
+static inline void pinMode(int pin, int mode)
+{
+    gpio_config_t io_conf = {0};
+    io_conf.pin_bit_mask = 1ULL << pin;
+    if (mode == OUTPUT) io_conf.mode = GPIO_MODE_OUTPUT;
+    else io_conf.mode = GPIO_MODE_INPUT;
+    gpio_config(&io_conf);
+}
+
+static inline void digitalWrite(int pin, int level)
+{
+    gpio_set_level((gpio_num_t)pin, level);
+}
+
+static inline int digitalRead(int pin)
+{
+    return gpio_get_level((gpio_num_t)pin);
+}
+
+static inline void delay(unsigned long ms)
+{
+    vTaskDelay(ms / portTICK_PERIOD_MS);
+}
+
+static inline void delayMicroseconds(unsigned int us)
+{
+    esp_rom_delay_us(us);
+}
+
+static inline unsigned long millis(void)
+{
+    return esp_timer_get_time() / 1000ULL;
+}
+
+static inline unsigned long micros(void)
+{
+    return esp_timer_get_time();
+}
+
+static inline void yield(void)
+{
+    vTaskDelay(0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ARDUINO_COMPAT_H

--- a/idf/HardwareSerial.cpp
+++ b/idf/HardwareSerial.cpp
@@ -1,0 +1,3 @@
+#include "HardwareSerial.h"
+
+HardwareSerial Serial;

--- a/idf/HardwareSerial.h
+++ b/idf/HardwareSerial.h
@@ -1,0 +1,18 @@
+#ifndef SERIAL_COMPAT_H
+#define SERIAL_COMPAT_H
+
+#include <stdio.h>
+#include <stdint.h>
+
+class HardwareSerial {
+public:
+    void begin(uint32_t baud) { (void)baud; }
+    void print(const char* s) { printf("%s", s); }
+    void println(const char* s) { printf("%s\n", s); }
+    void print(unsigned long v) { printf("%lu", v); }
+    void println(unsigned long v) { printf("%lu\n", v); }
+};
+
+extern HardwareSerial Serial;
+
+#endif // SERIAL_COMPAT_H

--- a/idf/SPI.cpp
+++ b/idf/SPI.cpp
@@ -1,0 +1,82 @@
+#include "SPI.h"
+
+#ifdef __cplusplus
+SPIClass SPI;
+#endif
+
+SPIClass::SPIClass(spi_host_device_t h) : handle(NULL), host(h),
+    sck_pin(-1), miso_pin(-1), mosi_pin(-1), cs_pin(-1),
+    cur_speed(0), cur_mode(0) {}
+
+void SPIClass::begin(int sck, int miso, int mosi, int ss)
+{
+    sck_pin = sck; miso_pin = miso; mosi_pin = mosi; cs_pin = ss;
+    spi_bus_config_t buscfg = {};
+    buscfg.miso_io_num = (miso >= 0) ? miso : -1;
+    buscfg.mosi_io_num = (mosi >= 0) ? mosi : -1;
+    buscfg.sclk_io_num = (sck >= 0) ? sck : -1;
+    buscfg.quadwp_io_num = -1;
+    buscfg.quadhd_io_num = -1;
+    buscfg.max_transfer_sz = 4096;
+
+    spi_bus_initialize(host, &buscfg, SPI_DMA_CH_AUTO);
+}
+
+void SPIClass::end()
+{
+    if (handle) {
+        spi_bus_remove_device(handle);
+        handle = NULL;
+    }
+    spi_bus_free(host);
+}
+
+void SPIClass::beginTransaction(SPISettings settings)
+{
+    // recreate device if parameters changed
+    if (handle && (cur_speed != settings.clock_speed_hz || cur_mode != settings.mode)) {
+        spi_bus_remove_device(handle);
+        handle = NULL;
+    }
+    if (!handle) {
+        spi_device_interface_config_t devcfg = {};
+        devcfg.clock_speed_hz = settings.clock_speed_hz;
+        devcfg.mode = settings.mode;
+        devcfg.spics_io_num = -1; // CS handled manually
+        devcfg.queue_size = 1;
+        spi_bus_add_device(host, &devcfg, &handle);
+        cur_speed = settings.clock_speed_hz;
+        cur_mode = settings.mode;
+    }
+    spi_device_acquire_bus(handle, portMAX_DELAY);
+}
+
+void SPIClass::endTransaction()
+{
+    if (handle) {
+        spi_device_release_bus(handle);
+    }
+}
+
+uint8_t SPIClass::transfer(uint8_t data)
+{
+    spi_transaction_t t = {};
+    uint8_t rx = 0;
+    t.length = 8;
+    t.tx_buffer = &data;
+    t.rx_buffer = &rx;
+    spi_device_polling_transmit(handle, &t);
+    return rx;
+}
+
+uint16_t SPIClass::transfer16(uint16_t data)
+{
+    spi_transaction_t t = {};
+    uint16_t rx = 0;
+    t.length = 16;
+    t.tx_buffer = &data;
+    t.rx_buffer = &rx;
+    spi_device_polling_transmit(handle, &t);
+    return rx;
+}
+

--- a/idf/SPI.h
+++ b/idf/SPI.h
@@ -1,0 +1,52 @@
+#ifndef SPI_COMPAT_H
+#define SPI_COMPAT_H
+
+#include "driver/spi_master.h"
+#include "Arduino.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MSBFIRST 1
+#define LSBFIRST 0
+
+#define SPI_MODE0 0
+#define SPI_MODE1 1
+#define SPI_MODE2 2
+#define SPI_MODE3 3
+
+typedef struct {
+    uint32_t clock_speed_hz;
+    uint8_t bit_order;
+    uint8_t mode;
+#ifdef __cplusplus
+    SPISettings(uint32_t clock = 4000000, uint8_t order = MSBFIRST, uint8_t m = SPI_MODE0)
+        : clock_speed_hz(clock), bit_order(order), mode(m) {}
+#endif
+} SPISettings;
+
+#ifdef __cplusplus
+}
+
+class SPIClass {
+public:
+    spi_device_handle_t handle;
+    spi_host_device_t host;
+    int sck_pin, miso_pin, mosi_pin, cs_pin;
+    uint32_t cur_speed;
+    uint8_t cur_mode;
+
+    explicit SPIClass(spi_host_device_t h=HSPI_HOST);
+    void begin(int sck=-1, int miso=-1, int mosi=-1, int ss=-1);
+    void end();
+    void beginTransaction(SPISettings settings);
+    void endTransaction();
+    uint8_t transfer(uint8_t data);
+    uint16_t transfer16(uint16_t data);
+};
+
+extern SPIClass SPI;
+#endif
+
+#endif // SPI_COMPAT_H

--- a/idf/avr/pgmspace.h
+++ b/idf/avr/pgmspace.h
@@ -1,0 +1,4 @@
+#ifndef AVR_PGMSPACE_H
+#define AVR_PGMSPACE_H
+#include "../pgmspace.h"
+#endif // AVR_PGMSPACE_H

--- a/idf/pgmspace.h
+++ b/idf/pgmspace.h
@@ -1,0 +1,7 @@
+#ifndef PGM_P_COMPAT_H
+#define PGM_P_COMPAT_H
+
+#define PROGMEM
+#define pgm_read_byte(addr) (*(const unsigned char*)(addr))
+
+#endif // PGM_P_COMPAT_H


### PR DESCRIPTION
## Summary
- provide missing SPI constants and constructor to SPISettings
- add transfer16 helper in SPI wrapper
- supply avr/pgmspace.h shim for sources that include AVR header

## Testing
- `cmake ..` *(fails: Unknown CMake command `idf_component_register`)*

------
https://chatgpt.com/codex/tasks/task_e_68464449219c832589e8b76232d93533