### PR TITLE
Add ESP‑IDF build integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 file(GLOB_RECURSE GXEPD2_SOURCES "src/*.cpp" "idf/*.cpp")
 
 idf_component_register(

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@
 - note that the new Waveshare Universal e-Paper Raw Panel Driver HAT Rev 2.3 needs PWR connected to VCC or driven HIGH
 - see https://www.waveshare.com/wiki/E-Paper_Driver_HAT
 
+### ESP-IDF Compatibility
+The library can be used directly in ESP-IDF projects.  A minimal
+`CMakeLists.txt` and legacy `component.mk` are provided so the component can be
+added to the project via `idf_component_register`.  Arduino style calls such as
+`digitalWrite`, `delay` or the global `SPI` and `Serial` objects are mapped to
+their ESP-IDF counterparts through the lightweight compatibility layer located
+in the `idf` folder.
+
 ### Paged Drawing, Picture Loop
  - This library uses paged drawing to limit RAM use and cope with missing single pixel update support
  - buffer size can be selected in the application by template parameter page_height, see GxEPD2_Example

--- a/component.mk
+++ b/component.mk
@@ -1,0 +1,3 @@
+COMPONENT_SRCDIRS := src idf
+COMPONENT_ADD_INCLUDEDIRS := src idf
+COMPONENT_REQUIRES := driver freertos


### PR DESCRIPTION
## Summary
- add `component.mk` for make-based ESP‑IDF builds
- add minimum cmake version to component CMakeLists
- document ESP‑IDF compatibility in README

## Testing
- `cmake ..` *(fails: Unknown CMake command `idf_component_register`)*

------
https://chatgpt.com/codex/tasks/task_e_68464e32756c8325a3f67417c4c6b182